### PR TITLE
🐛 Fix unzipping of extensions that already exist

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,7 @@
   unarchive:
     src: "/tmp/{{ item.name }}.zip"
     dest: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}"
+    creates: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}/metadata.json"
     remote_src: yes
   become_user: "{{ gnome_user }}"
   with_items: "{{ gnome_extensions|default([])}}"
@@ -96,4 +97,3 @@
   tags:
     - settings
     - dconf
-


### PR DESCRIPTION
This role works great for the initial installation of extensions, but
running a second time leads to this task failing with an
UnarchiveError with a message of the form "Cannot change group
ownership of `<file path>` to `<user>`, as user `<user>`"

Ideally the unarchive module would just move past files that already
exist in the destination (at least when the file hash is
identical...), but it doesn't seem to.

Since we know that every extension will have a metadata.json file, we
can use the 'creates' parameter to conditionally skip this unarchiving
if this file already exists.

See the docs for unarchive for more information on this parameter:
https://docs.ansible.com/ansible/latest/modules/unarchive_module.html