### PR TITLE
Allow specifying a schema directory for gsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Example Playbook
       - schema: org.gnome.desktop.interface
         key: monospace-font-name
         value: '"Source Code Pro Medium 16"'
+      - schema: org.gnome.shell.extensions.dash-to-panel
+        schemadir: ~/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/schemas
+        key: panel-position
+        value: TOP
     gnome_dconf:
       - key: /org/gnome/desktop/background/show-desktop-icons
         value: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,7 @@
     - extensions
 
 - name: Modify application settings using gsettings
-  shell: dbus-launch gsettings set {{ item.schema }} {{ item.key }} {{ item.value }}
+  shell: gsettings {{ ('--schemadir ' + item.schemadir) if 'schemadir' in item else '' }} set {{ item.schema }} {{ item.key }} {{ item.value }}
   become_user: "{{ gnome_user }}"
   with_items: "{{ gnome_gsettings|default([]) }}"
   tags:


### PR DESCRIPTION
This allows configuration of gnome-shell extensions (e.g. dash-to-panel).

I'm not quite sure what prefixing the command with 'dbus-launch` does and whether it's important to do so (since it seems to work perfectly fine without that prefix) - please clarify (@PeterMosmans).

I removed dbus-launch because it produces the following bug:

1. Install dash-to-panel and set panel location to 'TOP' via the ansible role (with `dbus-launch` in `Modify application settings using gsettings`)

    Variables:
    ```
    gnome_extensions:
    - id: 1160
    gnome_gsettings:
    - schema: org.gnome.shell.extensions.middleclickclose
      schemadir: ~/.local/share/gnome-shell/extensions/middleclickclose@paolo.tranquilli.gmail.com/schemas
      key: rearrange-delay
      value: 200
    ```

2. Confirm that the settings have changed

    ```
    $ gsettings --schemadir ~/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/schemas get org.gnome.shell.extensions.dash-to-panel panel-position
    'TOP'
    ```

3. Restart gnome-shell (with alt+f2 'r') to be sure that's not causing the bug

4. Open `gnome-shell-extension-prefs` and click the cog-wheel to
configure dash-to-panel

    Notice how `Panel screen position` seems to be correctly set to 'Top'.

5. Close `gnome-shell-extension-prefs`

6. Take another look at the gsettings value

    ```
    $ gsettings --schemadir ~/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/schemas get org.gnome.shell.extensions.dash-to-panel panel-position
    'BOTTOM'
    ```

    Somehow this has changed from 'TOP' to 'BOTTOM' by opening
    `gnome-shell-extension-prefs` (behaves alike when using Gnome Tweaks
    instaed), looking at the setting and closing it again - without changing the setting!