### PR TITLE
use directly gnome_extensions_full

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,15 +69,11 @@
   include_tasks: get_extension_info.yml
   loop: "{{ gnome_extensions }}"
 
-- name: Use gnome_extensions_full
-  set_fact:
-    gnome_extensions: "{{ gnome_extensions_full }}"
-
 - name: Download GNOME Shell extensions
   get_url:
     url: "{{ item.url }}"
     dest: "/tmp/{{ item.name }}.zip"
-  loop: "{{ gnome_extensions|default([]) }}"
+  loop: "{{ gnome_extensions_full|default([]) }}"
   loop_control:
     label: "{{ item.name }}"
   tags:
@@ -88,7 +84,7 @@
     path: /home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}
     state: directory
   become_user: "{{ gnome_user }}"
-  loop: "{{ gnome_extensions|default([]) }}"
+  loop: "{{ gnome_extensions_full|default([]) }}"
   loop_control:
     label: "{{ item.name }}"
   tags:
@@ -101,7 +97,7 @@
     creates: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}/metadata.json"
     remote_src: yes
   become_user: "{{ gnome_user }}"
-  loop: "{{ gnome_extensions|default([]) }}"
+  loop: "{{ gnome_extensions_full|default([]) }}"
   loop_control:
     label: "{{ item.name }}"
   tags:
@@ -111,7 +107,7 @@
   ansible.builtin.command: gnome-shell-extension-tool -e {{ item.name }}
   become_user: "{{ gnome_user }}"
   when: item.enable | default(false)
-  loop: "{{ gnome_extensions | default([]) }}"
+  loop: "{{ gnome_extensions_full | default([]) }}"
   loop_control:
     label: "{{ item.name }}"
   register: r_gnome_enable_extension


### PR DESCRIPTION
This should fix https://github.com/PeterMosmans/ansible-role-customize-gnome/issues/8

the problem is that setting the existing fact `gnome_extensions` with the new created fact `gnome_extensions_full` does not work in `main.yml`: `gnome_extensions` is not updated at all (as I said, I'm pretty new to Ansible so I don't know why.. I could only guess that's related to how variables have precedence). With this patch, in `main.yml` we use directly `gnome_extensions_full` (which, in any case, is set to the original `gnome_extensions` in case `url` and `name` are provided directly).

With this patch, this now works:

```yaml
- name: Install Gnome Extensions
  include_role:
    name: petermosmans.customize-gnome
  vars:
    gnome_extensions:
      - id: 19 # User Theme
      - id: 3740 # Magic Lamp
```