### PR TITLE
take only the first 2 parts of gnome-shell version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      gnome-shell --version | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'
+      gnome-shell --version | sed 's/[^0-9.]*\([0-9]*\(\.[0-9]*\)\).*/\1/'
     executable: /bin/bash
   register: r_gnome_extension_parse_shell_version
   changed_when: no


### PR DESCRIPTION
Closes #15 

With this commit, the gnome-shell version is parsed taking only the first two numbers in the version (or just one, but nothing else), additional numbers would make the URL query to the gnome extensions site fail.

For example, given 42 it takes 42, given 42.2 it takes 42.2, given 42.2.1 it takes 42.2 (it discards the last number).

I've tested it manually on my playbooks and it works in Arch, Fedora, and Ubuntu.