### PR TITLE
Allow shell extension upgrade to work again

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,6 @@
   ansible.builtin.unarchive:
     src: "/tmp/{{ item.name }}.zip"
     dest: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}"
-    creates: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/{{ item.name }}/metadata.json"
     remote_src: yes
   become_user: "{{ gnome_user }}"
   loop: "{{ gnome_extensions_full|default([]) }}"


### PR DESCRIPTION
Fixes #17.

I believe it was broken by myself in #2 because of an earlier bug in Ansible itself. I can't reproduce that issue now, so I presume we don't need the workaround any longer.