### PR TITLE
fix: Handle unreleased GNOME Shell versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      gnome-shell --version | sed 's/[^0-9.]*\([0-9]*\(\.[0-9]*\)\).*/\1/'
+      gnome-shell --version | sed 's/GNOME Shell \(.*\)/\1/'
     executable: /bin/bash
   register: r_gnome_extension_parse_shell_version
   changed_when: no


### PR DESCRIPTION
If the version of GNOME Shell isn't released yet, it seems that `gnome-shell --version` will return a value that's unexpected here in this role.

For example, in Fedora 37 Beta, I get the following:

```
$ gnome-shell --version
GNOME Shell 43.rc
```

Before this change, this would be parsed to `43.`. The trailing `.` appears to be problematic when we use the version variable as a query param value in a request to extensions.gnome.org here:

https://github.com/PeterMosmans/ansible-role-customize-gnome/blob/0a395f24cddb33cd247153b51c5e8e7df718c7a4/tasks/get_extension_info.yml#L4

I don't know if there are any drawbacks to my approach here—I'm submitting it optimistically. :)