### PR TITLE
feat: add option to skip restarting gnome shell

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 gnome_user: "{{ ansible_user_id }}"
+customize_gnome__skip_restart_gnome_shell: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,7 @@
   become_user: "{{ gnome_user }}"
   ansible.builtin.command:
     cmd: killall -3 gnome-shell
-  when: unzipped_extension.changed
+  when: unzipped_extension.changed and not customize_gnome__skip_restart_gnome_shell
 
 - name: Enable extensions
   ansible.builtin.command: gnome-shell-extension-tool -e {{ item.name }}


### PR DESCRIPTION
Fixes #29 

Issue #25 introduced a hard-exit of the gnome desktop environment/shell when running the playbook against localhost.

This pull request adds a default variable and conditional to allow the user to skip the gnome shell restart.