### PR TITLE
fix: set extension archive to be world readable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,6 +77,7 @@
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "/tmp/{{ item.name }}.zip"
+    mode: 0644
   loop: "{{ gnome_extensions_full|default([]) }}"
   loop_control:
     label: "{{ item.name }}"


### PR DESCRIPTION
When systems default umask is set to `0027` for instance, downloaded extension archive could become unreadable for `gnome_user` if different from user running the playbook and that then makes the task that unzips the archive fail.

This pull request sets permissions explicitly to avoid this.